### PR TITLE
Replaced obsolete MineStat.IsServerUp() usage

### DIFF
--- a/DowntimeKuma/Core/DowntimeKuma/MonitorModules/MinecraftModule.cs
+++ b/DowntimeKuma/Core/DowntimeKuma/MonitorModules/MinecraftModule.cs
@@ -24,8 +24,7 @@ namespace DowntimeKuma.Core.DowntimeKuma.MonitorModules
 
                 var mc = new MineStat(host, port);
 
-#pragma warning disable CS0612 // Typ oder Element ist veraltet
-                if (mc.IsServerUp())
+                if (mc.ServerUp)
                 {
                     return new MonitorData()
                     {
@@ -41,7 +40,6 @@ namespace DowntimeKuma.Core.DowntimeKuma.MonitorModules
                         Success = false
                     };
                 }
-#pragma warning restore CS0612 // Typ oder Element ist veraltet
             }
             catch(Exception e)
             {


### PR DESCRIPTION
Dear Endelon Hosting,

The method `MineStatLib.MineStat.IsServerUp()` in the MineStat package is deprecated/obsolete and has been replaced by the autogenerated getter `MineStatLib.MineStat.ServerUp`.
This PR simply replaces the obsolete method call.

See [the C# example in the FragLand/minestat README](https://github.com/FragLand/minestat#c-example) for all available fields.

If you need any help in the future regarding MineStat, don't hesitate to start a discussion or open an issue at the repo.

Viel Erfolg! 😃

Best regards,
Felix